### PR TITLE
Convert a section header to simply be bolded markdown text.

### DIFF
--- a/notebooks/challenge/cam-chem_waccm/exercise_2.ipynb
+++ b/notebooks/challenge/cam-chem_waccm/exercise_2.ipynb
@@ -26,7 +26,7 @@
     "**To change the chemistry**, copy your chemistry preprocessor file chem_mech.in from CaseDocs to your case directory as my_chem_mech.in and change reaction rate for the O1D reaction with O2 to 1.65e-12. Point the simulation to your new mechanism file using ``CAM_CONFIG_OPTS`` and re-build and submit. Once the simulation is complete, compare the 5th day output to the results from exercise 1.\n",
     "\n",
     "\n",
-    "## Extra information:\n",
+    "**Extra information:**\n",
     "    \n",
     "The chemistry preprocessor generates CAM Fortran source code to solve chemistry. The input is an ASCII file listing chemical reactions and rates. The chemistry preprocessor input file used in your previous run is in your\n",
     "``$CASEROOT/CaseDocs/chem_mech.in``\n",
@@ -41,7 +41,6 @@
     "Below is an overview of the different types of reactions and rates that can be defined in the mechanism file.\n",
     "![chemistry preprocessor options example](../../../images/challenge/chemistry-preprocessor-info.png)\n",
     "\n",
-    "</section>    \n",
     "</div>\n"
    ]
   },


### PR DESCRIPTION
Final attempt, which will see if removing a markdown section also successfully removes the erroneous auto-generated `</section>` tag.