### PR TITLE
fixed single vs double quote typo

### DIFF
--- a/notebooks/diagnostics/pop/basics_pop.ipynb
+++ b/notebooks/diagnostics/pop/basics_pop.ipynb
@@ -236,11 +236,11 @@
     "casename = 'b.day2.1'\n",
     "\n",
     "# Here we point to the archive directory from your b.day2.1 simulation\n",
-    "pth = f\"/glade/scratch/{username}/archive/' + casename + '/ocn/hist/\"\n",
+    "pth = f\"/glade/scratch/{username}/archive/" + casename + "/ocn/hist/\"\n",
     "\n",
     "# If you were unable to successfully run the b.day2.1 simulation, then feel free to use\n",
     "# this provided simulation data instead:\n",
-    "#pth = '/glade/p/cesm/tutorial/tutorial_2023_archive/' + casename + '/ocn/hist/'\n",
+    "#pth = '/glade/p/cesm/tutorial/tutorial_2023_archive/" + casename + "/ocn/hist/'\n",
     "\n",
     "# Print path to screen\n",
     "pth"


### PR DESCRIPTION
POP basic diagnostics had a minor typo in path specification. This should fix it but is untested because I cannot get on jupyterhub.