### PR TITLE
Use $USER environment variable in CUPiD notebook

### DIFF
--- a/notebooks/diagnostics/cupid.ipynb
+++ b/notebooks/diagnostics/cupid.ipynb
@@ -191,7 +191,7 @@
     "# All parameters under global_params get passed to all the notebooks\n",
     "\n",
     "global_params:\n",
-    "  CESM_output_dir: /glade/derecho/scratch/USERNAME/archive  #<-Replace \"USERNAME\" with your own username\n",
+    "  CESM_output_dir: /glade/derecho/scratch/${USER}/archive\n",
     "  #Uncomment code here if you need a complete CESM tutorial simulation:\n",
     "  #CESM_output_dir: /glade/campaign/cesm/tutorial/tutorial_2023_archive\n",
     "  lc_kwargs:\n",
@@ -205,7 +205,7 @@
     "  num_procs: 8\n",
     "  ts_done: [False]\n",
     "  overwrite_ts: [False]\n",
-    "  ts_output_dir: /glade/derecho/scratch/USERNAME/archive #<-Replace \"USERNAME\" with your own username\n",
+    "  ts_output_dir: /glade/derecho/scratch/${USER}/archive\n",
     "  case_name: 'b1850.run_length'\n",
     "\n",
     "  #Variables can either be provided as a list (e.g. ['X', 'Y', 'Z']) or,\n",
@@ -342,7 +342,7 @@
    "id": "63d02026-9dc3-492d-a14d-5b05d854833f",
    "metadata": {},
    "source": [
-    "Now let's check if the time series files were generated successfully, by examining the directory we are writing the time series files to.  In the below command replace \"USERNAME\" with your username, and \"COMP\" with your components of choice (atm, lnd, ocn, ice, or glc):"
+    "Now let's check if the time series files were generated successfully, by examining the directory we are writing the time series files to.  In the below command replace \"COMP\" with your components of choice (atm, lnd, ocn, ice, or glc):"
    ]
   },
   {
@@ -352,7 +352,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ts_data_path=\"/glade/derecho/scratch/USERNAME/archive/COMP/proc/tseries\"\n",
+    "ts_data_path=\"/glade/derecho/scratch/${USER}/archive/COMP/proc/tseries\"\n",
     "ls $ts_data_path"
    ]
   },


### PR DESCRIPTION
@mnlevy1981 had the good idea of replacing sections which required users to manually add their username into the CUPiD example notebook with the $USER environment variable.  This should make that notebook run more smoothly, and have less chances for user error.

Fully tested the CUPiD notebook with these mods and everything worked as expected. 