### PR TITLE
Update Jupyterhub Casper queue.

### DIFF
--- a/notebooks/diagnostics/diagnostics.ipynb
+++ b/notebooks/diagnostics/diagnostics.ipynb
@@ -184,7 +184,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-warning\">\n",
-    "<strong>For this tutorial you should use the Queue `casper` and Project Account `UESM0013`. </strong><br><br>\n",
+    "<strong>For this tutorial you should use the Queue `tutorial` and Project Account `UESM0013`. </strong><br><br>\n",
     "</div>"
    ]
   },


### PR DESCRIPTION
Make sure participants use the "tutorial" queue and not the regular casper queue.