### PR TITLE
Update cupid.ipynb to include instructions on failures related to cupid-analysis being installed as a kernel

### DIFF
--- a/notebooks/diagnostics/cupid.ipynb
+++ b/notebooks/diagnostics/cupid.ipynb
@@ -416,7 +416,7 @@
    "source": [
     "# sometimes users report that the conda environment was not found. IF this happens, run the following lines and then continue:\n",
     "conda activate cupid-analysis\n",
-    "python -m ipykernel install --user --name=cupid-analysis",
+    "python -m ipykernel install --user --name=cupid-analysis\n",
     "conda activate cupid-infrastructure\n"
    ]
   },

--- a/notebooks/diagnostics/cupid.ipynb
+++ b/notebooks/diagnostics/cupid.ipynb
@@ -406,6 +406,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a61ae981-b725-4f8e-a08e-84f8c6c63697",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# sometimes users report that the conda environment was not found. IF this happens, run the following lines and then continue:\n",
+    "conda activate cupid-analysis\n",
+    "python -m ipykernel install --user --name=cupid-analysis",
+    "conda activate cupid-infrastructure\n"
+   ]
+  },
+
+  {
    "cell_type": "markdown",
    "id": "47b2e3aa",
    "metadata": {},


### PR DESCRIPTION
Based off this issue ticket: 
https://github.com/NCAR/CUPiD/issues/102