### PR TITLE
Update BGC challenge exercise for 2026 tutorial

### DIFF
--- a/notebooks/challenge/bgc/bgc.ipynb
+++ b/notebooks/challenge/bgc/bgc.ipynb
@@ -18,6 +18,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ec18022c-4ae1-404a-8688-f7b265310bfa",
+   "metadata": {},
+   "source": [
+    "### Caveat: Support for coupled biogeochemistry in CESM3 is still under development. So this content describes biogeochemical features in the context of CESM2. For example, resolutions that are referenced are resolutions used in CESM2."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "34516fd8-ed12-44c0-ba57-b684c1c279cf",
    "metadata": {},
    "source": [
@@ -205,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/challenge/bgc/bgc_exercise_1.ipynb
+++ b/notebooks/challenge/bgc/bgc_exercise_1.ipynb
@@ -5,7 +5,49 @@
    "id": "f406f992-92bd-4b17-9bd3-b99c5c8abaf3",
    "metadata": {},
    "source": [
-    "# 1: Set up a BGC case"
+    "### Caveat: Support for coupled biogeochemistry in CESM3 is still under development. So this content describes biogeochemical features in the context of CESM2. For example, experiments use CESM2 resolutions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11d78f47-b7dc-4bc7-af9e-284b010ef2ff",
+   "metadata": {},
+   "source": [
+    "# 1: Check out a sandbox of the most recent version of CESM2.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "465ba5c4-1a38-4931-ac27-0c1d76627a8b",
+   "metadata": {},
+   "source": [
+    "## Run the following commands in the parent directory of where you have checked out versions of CESM3.\n",
+    "\n",
+    "## Note that CESM2 manages versions of components of CESM with a tool called `manage_externals`, not `git-fleximod`, so the commands below differ from what you've used in CESM3."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d71a0ef3-316d-4fc9-9989-b0118c0a3936",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "```\n",
+    "cd /glade/u/home/$USER/code\n",
+    "git clone https://github.com/ESCOMP/CESM.git cesm2.1.5\n",
+    "cd /glade/u/home/$USER/code/cesm2.1.5\n",
+    "git checkout cesm2.1.5\n",
+    "./manage_externals/checkout_externals\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0a07ccc-fdee-4bf8-870f-a559401c63c6",
+   "metadata": {},
+   "source": [
+    "# 2: Set up a BGC case"
    ]
   },
   {
@@ -24,9 +66,20 @@
     "<div class=\"alert alert-info\">\n",
     "<strong>Exercise: Set up a BGC control case</strong><br><br>\n",
     " \n",
-    "Create a case called **b_1850** using the compset  ``B1850``  at ``f19_g17`` resolution. \n",
+    "Create a case called **b.e21.B1850.f19_g17.001** using the compset ``B1850`` at ``f19_g17`` resolution.\n",
     "\n",
-    "Create a case called **b_1850_bprp** using the compset ``B1850_BPRP`` at ``f19_g17`` resolution.\n",
+    "```\n",
+    "cd /glade/u/home/$USER/code/cesm2.1.5/cime/scripts\n",
+    "./create_newcase --case /glade/u/home/$USER/cases/b.e21.B1850.f19_g17.001 --compset B1850 --res f19_g17\n",
+    "```\n",
+    "\n",
+    "Create a case called **b.e21.B1850_BPRP.f19_g17.001** using the compset ``B1850_BPRP`` at ``f19_g17`` resolution.\n",
+    "\n",
+    "```\n",
+    "cd /glade/u/home/$USER/code/cesm2.1.5/cime/scripts\n",
+    "./create_newcase --case /glade/u/home/$USER/cases/b.e21.B1850_BPRP.f19_g17.001 --compset B1850 --res f19_g17\n",
+    "```\n",
+    "\n",
     "- What happens when you run create_newcase? Follow the instructions to get this working, but don't do it for real unless you know what you're doing.\n",
     "\n",
     "Run case.setup and preview_namelists for each case.\n",
@@ -73,7 +126,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Update BGC challenge exercise for 2026 tutorial.

The exercise still use CESM 2.1, as coupled BGC is still under development in CESM3.
The exercise give instruction on checking out CESM 2.1.5 and gives the
`create_newcase` command for the experiments.

I have tested the commands on derecho.